### PR TITLE
Pdfill does not install

### DIFF
--- a/bucket/pdfill-np.json
+++ b/bucket/pdfill-np.json
@@ -6,11 +6,15 @@
         "identifier": "Freeware",
         "url": "http://www.pdfill.com/license.html"
     },
-    "url": "http://www.plotsoft.com/download/PDFill_FREE_PDF_Editor_Basic.msi#/setup.msi_",
+	"url": "http://www.plotsoft.com/download/PDFill_FREE_PDF_Editor_Basic.exe#/pdfill-setup.exe",
+"pre_install": [
+        "if (!(is_admin)) {",
+        "    error \"Administrator rights are required to install $app.\"",
+        "    exit 1",
+        "}"
+    ],
+	"depends": "main/ghostscript",
     "installer": {
-        "script": "Start-Process -Wait msiexec \"/i `\"$dir\\setup.msi_`\" /qn\" -Verb RunAs"
-    },
-    "uninstaller": {
-        "script": "Start-Process -Wait msiexec \"/x `\"$dir\\setup.msi_`\" /qn\" -Verb RunAs"
+        "script": "Start-Process -Wait msiexec \"/i `\"$dir\\pdfill-setup.exe`\" /qn\" -Verb RunAs"
     }
 }


### PR DESCRIPTION
This is a app which wont run if you extract the msi, you have to manually open and install it. Thats why I linked to the exe file instead. And you have to do that as an admin or it will show errors. Also, ghostscript is required.