### PR TITLE
BiglyBT silent install to Scoop directory

### DIFF
--- a/bucket/biglybt-np.json
+++ b/bucket/biglybt-np.json
@@ -24,12 +24,6 @@
         "file": "uninstall.exe",
         "args": "-q"
     },
-    "suggest": {
-        "JDK": [
-            "java/openjdk",
-            "java/oraclejdk"
-        ]
-    },
     "bin": "BiglyBT.exe",
     "checkver": {
         "github": "https://github.com/BiglySoftware/BiglyBT"

--- a/bucket/biglybt-np.json
+++ b/bucket/biglybt-np.json
@@ -16,6 +16,10 @@
     "installer": {
         "args": "-q -dir '$dir'"
     },
+    "post_install": [
+        "Remove-Item 'C:\\Users\\Public\\Desktop\\BiglyBt.lnk'"
+        "Remove-Item 'C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\BiglyBt.lnk'"
+    ],
     "uninstaller": {
         "file": "uninstall.exe",
         "args": "-q"

--- a/bucket/biglybt-np.json
+++ b/bucket/biglybt-np.json
@@ -14,20 +14,11 @@
         }
     },
     "installer": {
-        "args": [
-            "/verysilent",
-            "/nocancel",
-            "/norestart",
-            "/dir=$dir"
-        ]
+        "args": "-q -dir '$dir'"
     },
     "uninstaller": {
         "file": "uninstall.exe",
-        "args": [
-            "/verysilent",
-            "/nocancel",
-            "/norestart"
-        ]
+        "args": "-q"
     },
     "suggest": {
         "JDK": [
@@ -35,6 +26,7 @@
             "java/oraclejdk"
         ]
     },
+    "bin": "BiglyBT.exe",
     "checkver": {
         "github": "https://github.com/BiglySoftware/BiglyBT"
     },


### PR DESCRIPTION
Those installer arguments are for InnoSetup, while BiglyBT uses Install4J
https://resources.ej-technologies.com/install4j/help/doc/help.pdf
Also, why are we suggesting JDK, when it is a self contained app ?