### PR TITLE
nvidia-display-driver: stop telemetry service

### DIFF
--- a/bucket/nvidia-display-driver.json
+++ b/bucket/nvidia-display-driver.json
@@ -31,7 +31,9 @@
             "",
             "Start-Process -Wait \"$dir\\setup\\setup.exe\" \"-s -noreboot\" -Verb RunAs",
             "Remove-Item -Recurse \"$dir\\extract\"",
-            "Remove-Item -Recurse \"$dir\\setup\""
+            "Remove-Item -Recurse \"$dir\\setup\"",
+            "Stop-Service NVDisplay.ContainerLocalSystem",
+            "Stop-Service NVDisplay.ContainerLocalSystem -StartupType Disabled"
         ]
     },
     "checkver": {


### PR DESCRIPTION
The installer automatically starts and enables a telemetry reporting service after successful installation.  This change stops and disables that service as part of the install script.  I have been using this successfully in my personal bucket for some time now: https://github.com/matoro/bucket/blob/master/nvidia-display-driver.json