### PR TITLE
vmware-horizon-client-np: add checkver, autoupdate

### DIFF
--- a/bucket/vmware-horizon-client-np.json
+++ b/bucket/vmware-horizon-client-np.json
@@ -28,5 +28,12 @@
                 ]
             ]
         }
+    },
+    "checkver": {
+        "url": "https://my.vmware.com/web/vmware/details?productId=863&downloadGroup=CART20FQ4_WIN_530",
+        "regex": "(?<downloadgroup>CART[\\d]+FQ[\\d])/VMware-Horizon-Client-(?<version>[\\d.]+-[\\d]+).exe"
+    },
+    "autoupdate": {
+        "url": "https://download3.vmware.com/software/view/viewclients/$matchDownloadgroup/VMware-Horizon-Client-$version.exe#/VMware-Horizon-Client-Setup.exe"
     }
 }

--- a/bucket/vmware-horizon-client-np.json
+++ b/bucket/vmware-horizon-client-np.json
@@ -31,9 +31,9 @@
     },
     "checkver": {
         "url": "https://my.vmware.com/web/vmware/details?productId=863&downloadGroup=CART20FQ4_WIN_530",
-        "regex": "(?<downloadgroup>CART[\\d]+FQ[\\d])/VMware-Horizon-Client-(?<version>[\\d.]+-[\\d]+).exe"
+        "regex": "(?<downloadGroup>CART[\\d]+FQ[\\d])/VMware-Horizon-Client-(?<version>[\\d.]+-[\\d]+).exe"
     },
     "autoupdate": {
-        "url": "https://download3.vmware.com/software/view/viewclients/$matchDownloadgroup/VMware-Horizon-Client-$version.exe#/VMware-Horizon-Client-Setup.exe"
+        "url": "https://download3.vmware.com/software/view/viewclients/$matchDownloadGroup/VMware-Horizon-Client-$version.exe#/VMware-Horizon-Client-Setup.exe"
     }
 }


### PR DESCRIPTION
Add support for [checkver and autoupdate](https://github.com/lukesampson/scoop/wiki/App-Manifest-Autoupdate#using-checkverps1-to-query-and-autoupdate) to simplify maintenance of
`vmware-horizon-client-np` manifest. Have not found a central registry for
VMware Horizon Client versions, so the `downloadGroup` parameter in
`checkver.url` requires manual update.

Due to the manual update requirement for download group with each minor
release, unsure if this makes the `checkver` and `autoupdate` worth it.
If nothing else this helps prevent typos in version or hash.