### PR TITLE
sshfs-np, winfsp-np: Modify installer

### DIFF
--- a/bucket/sshfs-np.json
+++ b/bucket/sshfs-np.json
@@ -17,17 +17,11 @@
     "depends": {
         "winfsp-np": "winfsp-np"
     },
-    "pre_install": [
-        "if (-not (is_admin)) {",
-        "    Write-Host 'Elevated prompt is needed for correct installation.' -f Yellow",
-        "    exit(1)",
-        "}"
-    ],
     "installer": {
-        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi_\", '/qn') | Out-Null"
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi_\", '/qn') -RunAs | Out-Null"
     },
     "uninstaller": {
-        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/x', \"$dir\\setup.msi_\", '/qn') | Out-Null"
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/x', \"$dir\\setup.msi_\", '/qn') -RunAs | Out-Null"
     },
     "checkver": {
         "url": "https://github.com/billziss-gh/sshfs-win/releases/latest",

--- a/bucket/winfsp-np.json
+++ b/bucket/winfsp-np.json
@@ -6,17 +6,11 @@
     "license": "GPL-3.0-only",
     "url": "https://github.com/billziss-gh/winfsp/releases/download/v1.4.19049/winfsp-1.4.19049.msi#/setup.msi_",
     "hash": "3c6df9f7bb505d6796e886efcfc19dcf25d76053832f139bc2f2627be0fa8324",
-    "pre_install": [
-        "if (-not (is_admin)) {",
-        "    Write-Host 'Elevated prompt is needed for correct installation.' -f Yellow",
-        "    exit(1)",
-        "}"
-    ],
     "installer": {
-        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi_\", '/qn') | Out-Null"
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi_\", '/qn') -RunAs | Out-Null"
     },
     "uninstaller": {
-        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/x', \"$dir\\setup.msi_\", '/qn') | Out-Null"
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/x', \"$dir\\setup.msi_\", '/qn') -RunAs | Out-Null"
     },
     "checkver": {
         "url": "https://github.com/billziss-gh/winfsp/releases/latest",


### PR DESCRIPTION
`Invoke-ExternalCommand ... -RunAs` works properly after https://github.com/lukesampson/scoop/pull/3547. 
(Will popup an **UAC prompt** when not running under Admin rights) 

Therefore, the tweak in `pre_install` section is not needed anymore.