### PR TITLE
fluent-terminal : Remove prompt after installation

### DIFF
--- a/bucket/fluent-terminal-np.json
+++ b/bucket/fluent-terminal-np.json
@@ -18,7 +18,7 @@
         "gpupdate /force",
         "reg add 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock' /t REG_DWORD /f /v 'AllowAllTrustedApps' /d 1"
     ],
-    "post_install": "& \"$dir\\Install.ps1\" -ForceContextMenu",
+    "post_install": "& \"$dir\\Install.ps1\" -ForceContextMenu -Force",
     "uninstaller": {
         "script": [
             "if (!(is_admin)) {",


### PR DESCRIPTION
After installation, it asks 'Press Enter to continue'. Adding a -Force flag to post-install script seems to remove that prompt.