### PR TITLE
fman-np: installer tweaks

### DIFF
--- a/bucket/fman-np.json
+++ b/bucket/fman-np.json
@@ -1,6 +1,6 @@
 {
     "version": "1.7.0",
-    "description": "Dual-pane file manager",
+    "description": "Dual-pane file manager.",
     "homepage": "https://fman.io",
     "license": {
         "identifier": "Proprietary",

--- a/bucket/fman-np.json
+++ b/bucket/fman-np.json
@@ -1,15 +1,23 @@
 {
     "version": "1.7.0",
-    "description": "Dual-pane file manager.",
+    "description": "Dual-pane file manager",
     "homepage": "https://fman.io",
     "license": {
         "identifier": "Proprietary",
-        "url": "https://fman.io/buy"
+        "url": "https://fman.io/legal"
     },
-    "url": "https://download.fman.io/1.7.0/fmanSetup.exe",
+    "url": "https://download.fman.io/1.7.0/fmanSetup.exe#/setup.exe",
     "hash": "185af83cb9b3ecc0f8f9e428e01d1850aeab6cbfcad227fcfea53aa4563dad90",
     "installer": {
-        "args": "/S"
+        "script": [
+            "Start-Process \"$dir\\setup.exe\" -ArgumentList '/S' | Out-Null",
+            "while ($true) {",
+                "if (Get-Process -Name fman -ErrorAction SilentlyContinue) { Stop-Process -Name fman -Force }",
+                "if (!(Get-Process -Name setup -ErrorAction SilentlyContinue)) { break }",
+                "Start-Sleep -Seconds 1",
+            "}",
+            "Remove-Item \"$dir\\setup.exe\""
+        ]
     },
     "uninstaller": {
         "script": [
@@ -22,6 +30,6 @@
         "regex": "Version ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://download.fman.io/$version/fmanSetup.exe"
+        "url": "https://download.fman.io/$version/fmanSetup.exe#/setup.exe"
     }
 }


### PR DESCRIPTION
* The installer(setup.exe) automatically opens *fman* (as a child process of the installer) before closing. This **installer.script** deals with the problem.

* Change license URL from `https://fman.io/buy` to `https://fman.io/legal`.

Please let me know if there are any problems. Thanks.