### PR TITLE
lantern-client-np: Add version 5.8.1

### DIFF
--- a/bucket/lantern-client-np.json
+++ b/bucket/lantern-client-np.json
@@ -16,7 +16,7 @@
         ]
     },
     "uninstaller": {
-        "script": "Invoke-ExternalCommand \"$dir\\uninstall.exe\" -ArgumentList @('/S', \"/D=$dir\") | Out-Null"
+        "script": "Invoke-ExternalCommand \"$dir\\uninstall.exe\" -ArgumentList '/S' | Out-Null"
     },
     "bin": "lantern.exe",
     "shortcuts": [

--- a/bucket/lantern-client-np.json
+++ b/bucket/lantern-client-np.json
@@ -1,0 +1,40 @@
+{
+    "##": "This package was added because the installer cannot be properly extracted after version 5.5.6.",
+    "homepage": "https://getlantern.org",
+    "description": "HTTP/HTTPS proxy.",
+    "version": "5.8.1",
+    "license": "Apache-2.0",
+    "url": "https://raw.githubusercontent.com/getlantern/lantern-binaries/master/lantern-installer.exe#/setup.exe",
+    "hash": "f11c08f0d408acb838a0a8fd7d99f7e870ca894cff4bcf2cb3d21727e2d80eb1",
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList @('/S', \"/D=$dir\") | Out-Null",
+            "Remove-Item \"$dir\\setup.exe\"",
+            "Remove-Item \"$Env:AppData\\Microsoft\\Windows\\Start Menu\\Programs\\Lantern\" -Force -Recurse",
+            "$UserDesktop = [Environment]::GetFolderPath('Desktop')",
+            "Remove-Item \"$UserDesktop\\Lantern.lnk\""
+        ]
+    },
+    "uninstaller": {
+        "script": "Invoke-ExternalCommand \"$dir\\uninstall.exe\" -ArgumentList @('/S', \"/D=$dir\") | Out-Null"
+    },
+    "bin": "lantern.exe",
+    "shortcuts": [
+        [
+            "lantern.exe",
+            "Lantern",
+            "",
+            "lantern.ico"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/getlantern/lantern-binaries/commits/master/lantern-installer.exe",
+        "regex": "Lantern ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/getlantern/lantern-binaries/master/lantern-installer.exe#/setup.exe",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/lantern-np.json
+++ b/bucket/lantern-np.json
@@ -1,8 +1,8 @@
 {
-    "##": "This package was added because the installer cannot be properly extracted after version 5.5.6.",
-    "homepage": "https://getlantern.org",
-    "description": "HTTP/HTTPS proxy.",
+    "##": "This package is nonportable because the installer cannot be properly extracted after version 5.5.6.",
     "version": "5.8.1",
+    "description": "HTTP/HTTPS proxy.",
+    "homepage": "https://getlantern.org/",
     "license": "Apache-2.0",
     "url": "https://raw.githubusercontent.com/getlantern/lantern-binaries/master/lantern-installer.exe#/setup.exe",
     "hash": "f11c08f0d408acb838a0a8fd7d99f7e870ca894cff4bcf2cb3d21727e2d80eb1",
@@ -10,9 +10,8 @@
         "script": [
             "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList @('/S', \"/D=$dir\") | Out-Null",
             "Remove-Item \"$dir\\setup.exe\"",
-            "Remove-Item \"$Env:AppData\\Microsoft\\Windows\\Start Menu\\Programs\\Lantern\" -Force -Recurse",
-            "$UserDesktop = [Environment]::GetFolderPath('Desktop')",
-            "Remove-Item \"$UserDesktop\\Lantern.lnk\""
+            "Remove-Item -Recurse \"$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs\\Lantern\"",
+            "Remove-Item \"$env:USERPROFILE\\Desktop\\Lantern.lnk\""
         ]
     },
     "uninstaller": {


### PR DESCRIPTION
This package is added because the installer of **lantern-client** cannot be properly extracted after version 5.5.6.

Also see:
https://github.com/lukesampson/scoop-extras/issues/3581
https://github.com/lukesampson/scoop-extras/pull/3583