### PR TITLE
google-japanese-input-np: Add version 2.25.3700.0

### DIFF
--- a/bucket/google-japanese-input-np.json
+++ b/bucket/google-japanese-input-np.json
@@ -1,0 +1,39 @@
+{
+    "version": "2.25.3700.0",
+    "description": "Japanese input method (IME) published by Google.",
+    "homepage": "https://www.google.co.jp/ime/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://tools.google.com/dlpage/japaneseinput/eula.html?platform=win&hl=en"
+    },
+    "architecture": {
+        "32bit": {
+            "url": "https://dl.google.com/japanese-ime/2.25.3700.0/googlejapaneseinput32.msi#/setup.msi_",
+            "hash": "b88c352448047d53733514b15e17e2f8fa75483c093b79f328533ce1774c7809"
+        },
+        "64bit": {
+            "url": "https://dl.google.com/japanese-ime/2.25.3700.0/googlejapaneseinput64.msi#/setup.msi_",
+            "hash": "a199b9731008215f3ed9ba06b00a3d62bf7407781418a5f7c37612ab6483b773"
+        }
+    },
+    "installer": {
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi_\", '/qn', '/norestart') -RunAs | Out-Null"
+    },
+    "uninstaller": {
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/x', \"$dir\\setup.msi_\", '/qn', '/norestart') -RunAs -ContinueExitCodes @{3010 = 'You may need to restart the computer for Google Japanese Input to be completely removed.'} | Out-Null"
+    },
+    "checkver": {
+        "url": "https://forest.watch.impress.co.jp/library/software/googleime/",
+        "regex": "<dd>v([\\d.]+)</dd></dl>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://dl.google.com/japanese-ime/$version/googlejapaneseinput32.msi#/setup.msi_"
+            },
+            "64bit": {
+                "url": "https://dl.google.com/japanese-ime/$version/googlejapaneseinput64.msi#/setup.msi_"
+            }
+        }
+    }
+}

--- a/bucket/google-japanese-input-np.json
+++ b/bucket/google-japanese-input-np.json
@@ -1,19 +1,19 @@
 {
     "version": "2.25.3700.0",
-    "description": "Japanese input method (IME) published by Google.",
+    "description": "Japanese input method (IME) by Google.",
     "homepage": "https://www.google.co.jp/ime/",
     "license": {
         "identifier": "Freeware",
         "url": "https://tools.google.com/dlpage/japaneseinput/eula.html?platform=win&hl=en"
     },
     "architecture": {
-        "32bit": {
-            "url": "https://dl.google.com/japanese-ime/2.25.3700.0/googlejapaneseinput32.msi#/setup.msi_",
-            "hash": "b88c352448047d53733514b15e17e2f8fa75483c093b79f328533ce1774c7809"
-        },
         "64bit": {
             "url": "https://dl.google.com/japanese-ime/2.25.3700.0/googlejapaneseinput64.msi#/setup.msi_",
             "hash": "a199b9731008215f3ed9ba06b00a3d62bf7407781418a5f7c37612ab6483b773"
+        },
+        "32bit": {
+            "url": "https://dl.google.com/japanese-ime/2.25.3700.0/googlejapaneseinput32.msi#/setup.msi_",
+            "hash": "b88c352448047d53733514b15e17e2f8fa75483c093b79f328533ce1774c7809"
         }
     },
     "installer": {
@@ -28,11 +28,11 @@
     },
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://dl.google.com/japanese-ime/$version/googlejapaneseinput32.msi#/setup.msi_"
-            },
             "64bit": {
                 "url": "https://dl.google.com/japanese-ime/$version/googlejapaneseinput64.msi#/setup.msi_"
+            },
+            "32bit": {
+                "url": "https://dl.google.com/japanese-ime/$version/googlejapaneseinput32.msi#/setup.msi_"
             }
         }
     }


### PR DESCRIPTION
**Google Japanese Input** ([homepage](https://www.google.co.jp/ime/)) ([Wikipedia](https://en.wikipedia.org/wiki/Google_Japanese_Input)) is a Japanese input method (IME) published by Google.

Notes:
* **checkver**: I couldn't find an official page that has the **latest version number**. Therefore I use a third-party website instead. Is this acceptable?