### PR TITLE
lightscribe-system-software-np: Add version 1.18.27.10

### DIFF
--- a/bucket/lightscribe-system-software-np.json
+++ b/bucket/lightscribe-system-software-np.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.18.27.10",
+    "description": "Softwares required for LightScribe disk drives to work. (also called LightScribe drivers)",
+    "homepage": "https://lightscribesoftware.org/lightscribe-system-software/",
+    "license": "Freeware",
+    "depends": "uniextract2",
+    "url": "http://www.pawtec.com/lightscribe_files/PC/LS_Update_1.18.27.10_.exe#/setup.exe",
+    "hash": "486c2db5ab06224e0be25dbc04634edae510acbb1d9af0d2cf3257a4a5f570a7",
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand uniextract -ArgumentList @(\"$dir\\setup.exe\", \"$dir\\setup\", '/silent') | Out-Null",
+            "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup\\LS_HSI.msi\", '/qn', '/norestart') -RunAs | Out-Null",
+            "Remove-Item \"$dir\\setup.exe\""
+        ]
+    },
+    "uninstaller": {
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/x', \"$dir\\setup\\LS_HSI.msi\", '/qn', '/norestart') -RunAs | Out-Null"
+    }
+}

--- a/bucket/lightscribe-system-software-np.json
+++ b/bucket/lightscribe-system-software-np.json
@@ -1,6 +1,6 @@
 {
     "version": "1.18.27.10",
-    "description": "Softwares required for LightScribe disk drives to work. (also called LightScribe drivers)",
+    "description": "LightScribe disk drive software.",
     "homepage": "https://lightscribesoftware.org/lightscribe-system-software/",
     "license": "Freeware",
     "depends": "uniextract2",


### PR DESCRIPTION
**LightScribe System Software** ([homepage](https://lightscribesoftware.org/lightscribe-system-software/)) is the software required for LightScribe disk drives to work. (also called LightScribe drivers)

Notes:
* *checkver/autoupdate* is not needed because *LightScribe System Software* has not been updated since 2013.

* The license can be found in `license.rtf` under installation path.

* *LightScribe System Software* is installed at `$Env:PROGRAMFILES(X86)\Common Files` on 64-bit machines, but it's `$Env:PROGRAMFILES\Common Files` on 32-bit machines. Therefore I keep the original installer (`LS_HSI.msi`) to avoid tricky situations for **uninstalling**.