### PR TITLE
lightscribe-system-software-np: Fix typo

### DIFF
--- a/bucket/lightscribe-system-software-np.json
+++ b/bucket/lightscribe-system-software-np.json
@@ -1,6 +1,6 @@
 {
     "version": "1.18.27.10",
-    "description": "LightScribe disk drive software.",
+    "description": "LightScribe disc drive software.",
     "homepage": "https://lightscribesoftware.org/lightscribe-system-software/",
     "license": "Freeware",
     "depends": "uniextract2",


### PR DESCRIPTION
Should be LightScribe disc drive, not "disk" drive. Sorry for the stupid mistake.