### PR TITLE
notepadplusplus-np: keep user settings during update

### DIFF
--- a/bucket/notepadplusplus-np.json
+++ b/bucket/notepadplusplus-np.json
@@ -16,11 +16,14 @@
     "installer": {
         "script": [
             "Invoke-ExternalCommand \"$dir\\installer.exe\" -ArgumentList @('/S', \"/D=$dir\") -RunAs | Out-Null",
-            "Remove-Item \"$env:ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Notepad++.lnk\""
+            "Remove-Item \"$env:ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Notepad++.lnk\"",
+            "if (Test-Path(\"$env:AppData\\Notepad++_Scoop_backup\")) { Copy-Item \"$env:AppData\\Notepad++_Scoop_backup\\*\" \"$Env:AppData\\Notepad++\" -Force -Recurse }"
         ]
     },
     "uninstaller": {
         "script": [
+            "if (!(Test-Path(\"$env:AppData\\Notepad++_Scoop_backup\"))) { New-Item \"$env:AppData\\Notepad++_Scoop_backup\" -ItemType Directory }",
+            "Copy-Item \"$Env:AppData\\Notepad++\\*\" \"$env:AppData\\Notepad++_Scoop_backup\" -Force -Recurse",
             "Invoke-ExternalCommand \"$dir\\uninstall.exe\" -ArgumentList @('/S') -RunAs | Out-Null",
             "Stop-Process -Name explorer"
         ]


### PR DESCRIPTION
mentioned in https://github.com/TheRandomLabs/scoop-nonportable/issues/69#issuecomment-595703511.

The installer/uninstaller of **Notepad++** will reset user settings (stored in `$Env:AppData\Notepad++`) when silent switch (`/S`) is applied. This causes **user settings lost** when the user updates *Notepad++* through Scoop.

This solves the issue by copying the user settings folder during install/uninstall.

