### PR TITLE
winbtrfs-np: Add version 1.7.1

### DIFF
--- a/bucket/winbtrfs-np.json
+++ b/bucket/winbtrfs-np.json
@@ -1,9 +1,9 @@
 {
     "version": "1.7.1",
-    "description": "Driver for the Btrfs filesystem.",
+    "description": "Btrfs filesystem driver.",
     "homepage": "https://github.com/maharmstone/btrfs",
     "license": "LGPL-3.0-or-later",
-    "notes": "If you get a signing error when trying to install the driver, try disabling Secure Boot in your BIOS settings.",
+    "notes": "Secure Boot may need to be disabled in the BIOS settings in the event of a signing error.",
     "url": "https://github.com/maharmstone/btrfs/releases/download/v1.7.1/btrfs-1.7.1.zip",
     "hash": "86c543a8bf158fc41927aa04d02c35aa7b7e8620f39af06cf7e259f88aa0f672",
     "installer": {

--- a/bucket/winbtrfs-np.json
+++ b/bucket/winbtrfs-np.json
@@ -1,0 +1,17 @@
+{
+    "version": "1.7.1",
+    "description": "Driver for the Btrfs filesystem.",
+    "homepage": "https://github.com/maharmstone/btrfs",
+    "license": "LGPL-3.0-or-later",
+    "notes": [
+        "You can now remove the installer with 'scoop uninstall winbtrfs'.",
+        "If you get a signing error when trying to install the driver, try disabling Secure Boot in your BIOS settings."
+    ],
+    "url": "https://github.com/maharmstone/btrfs/releases/download/v1.7.1/btrfs-1.7.1.zip",
+    "hash": "86c543a8bf158fc41927aa04d02c35aa7b7e8620f39af06cf7e259f88aa0f672",
+    "pre_install": "Invoke-ExternalCommand PNPUtil -ArgumentList @('/add-driver', \"$dir\\btrfs.inf\", '/install') -RunAs | Out-Null",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/maharmstone/btrfs/releases/download/v$version/btrfs-$version.zip"
+    }
+}

--- a/bucket/winbtrfs-np.json
+++ b/bucket/winbtrfs-np.json
@@ -3,13 +3,15 @@
     "description": "Driver for the Btrfs filesystem.",
     "homepage": "https://github.com/maharmstone/btrfs",
     "license": "LGPL-3.0-or-later",
-    "notes": [
-        "You can now remove the installer with 'scoop uninstall winbtrfs'.",
-        "If you get a signing error when trying to install the driver, try disabling Secure Boot in your BIOS settings."
-    ],
+    "notes": "If you get a signing error when trying to install the driver, try disabling Secure Boot in your BIOS settings.",
     "url": "https://github.com/maharmstone/btrfs/releases/download/v1.7.1/btrfs-1.7.1.zip",
     "hash": "86c543a8bf158fc41927aa04d02c35aa7b7e8620f39af06cf7e259f88aa0f672",
-    "pre_install": "Invoke-ExternalCommand PNPUtil -ArgumentList @('/add-driver', \"$dir\\btrfs.inf\", '/install') -RunAs | Out-Null",
+    "installer": {
+        "script": "Invoke-ExternalCommand PNPUtil -ArgumentList @('/add-driver', \"$dir\\btrfs.inf\", '/install') -RunAs | Out-Null"
+    },
+    "uninstaller": {
+        "script": "Invoke-ExternalCommand PNPUtil -ArgumentList @('/delete-driver', \"$dir\\btrfs.inf\", '/uninstall') -RunAs | Out-Null"
+    },
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/maharmstone/btrfs/releases/download/v$version/btrfs-$version.zip"


### PR DESCRIPTION
**WinBtrfs** ([Github repo](https://github.com/maharmstone/btrfs)) is a Windows driver for the next-generation Linux filesystem *Btrfs*.

Notes:
* This manifest follows the pattern of [VCRedist packages](https://github.com/lukesampson/scoop-extras/blob/master/bucket/vcredist2019.json).

* The "signing error problem" is described the [readme file](https://github.com/maharmstone/btrfs#installation).