### PR TITLE
mactype-np: Add version 2019.1-beta6

### DIFF
--- a/bucket/mactype-np.json
+++ b/bucket/mactype-np.json
@@ -1,0 +1,54 @@
+{
+    "##": "The installer of MacType is created with AdvancedInstaller.",
+    "version": "2019.1-beta6",
+    "description": "Provides better font rendering for Windows.",
+    "homepage": "https://mactype.net",
+    "license": "GPL-3.0-or-later",
+    "notes": [
+        "Launch MacType Wizard (macwiz.exe) to configure MacType.",
+        "",
+        "Antivirus software may conflict with MacType, because it sees MacType trying to modify running software.",
+        "One possible workaround is to try running in Service Mode (recommended),",
+        " or add HookChildProcesses=0 to your profile.",
+        "See 'https://github.com/snowie2000/mactype/wiki/HookChildProcesses' for explanation."
+    ],
+    "url": "https://github.com/snowie2000/mactype/releases/download/2019.1-beta6/MacTypeInstaller_2019.1-beta6.exe#/dl.exe",
+    "hash": "d4d84bbb0d67480ac9c19d9f60874a496c84c54852e12f6b85e1c8ccb8c123ed",
+    "depends": "uniextract2",
+    "pre_install": [
+        "Invoke-ExternalCommand uniextract -ArgumentList @(\"$dir\\dl.exe\", \"$dir\", '/silent') | Out-Null",
+        "Remove-Item \"$dir\\dl.exe\""
+    ],
+    "uninstaller": {
+        "script": [
+            "$text = @(",
+            "    'If you encounter \"file in use\" error during uninstallation, try the follwing steps:'",
+            "    '    1. Launch MacType Wizard (macwiz.exe) and select \"Manual\" mode.'",
+            "    '    2. If your previous mode is not manual mode, reboot your computer.'",
+            "    '    3. Run \"scoop uninstall mactype-np\" to uninstall the package.'",
+            ")",
+            "warn $($text -join \"`r`n\")"
+        ]
+    },
+    "bin": [
+        "MacTray.exe",
+        "MacWiz.exe"
+    ],
+    "shortcuts": [
+        [
+            "MacTray.exe",
+            "MacType Tray"
+        ],
+        [
+            "MacWiz.exe",
+            "MacType Wizard"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/snowie2000/mactype/releases",
+        "regex": "download/([\\w.-]+)/(?<filename>MacTypeInstaller_[\\w._-]+\\.exe)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/snowie2000/mactype/releases/download/$version/$matchFilename#/dl.exe"
+    }
+}


### PR DESCRIPTION
**MacType**([Github repo](https://github.com/snowie2000/mactype)) is a tool that provides better font rendering for Windows.

Notes:
* This package is sent to here (instead of the *extras* bucket) because **MacType** involves too many system tweaking, which does not meet the criteria of the *extras* bucket.

* I use the "beta version" because "stable version" has not been updated for 2 years. Also, the installer used in newer versions is different from the older versions. Using newer ones can avoid future maintainance issues.

* The *notes* are written according to [known issues](https://github.com/snowie2000/mactype#known-issues) and [developer's reply about the uninstallation problem](https://github.com/snowie2000/mactype/issues/133).