### PR TITLE
mactype-np: Remove uniextract2 dependency, simplify manifest 

### DIFF
--- a/bucket/mactype-np.json
+++ b/bucket/mactype-np.json
@@ -12,20 +12,16 @@
         "- Run in Service Mode (recommended)",
         "- Add `HookChildProcesses=0` to profile; see: https://github.com/snowie2000/mactype/wiki/HookChildProcesses"
     ],
-    "url": "https://github.com/snowie2000/mactype/releases/download/2019.1-beta6/MacTypeInstaller_2019.1-beta6.exe#/dl.exe",
+    "url": "https://github.com/snowie2000/mactype/releases/download/2019.1-beta6/MacTypeInstaller_2019.1-beta6.exe",
     "hash": "d4d84bbb0d67480ac9c19d9f60874a496c84c54852e12f6b85e1c8ccb8c123ed",
-    "depends": "uniextract2",
-    "pre_install": [
-        "Invoke-ExternalCommand uniextract -ArgumentList @(\"$dir\\dl.exe\", \"$dir\", '/silent') | Out-Null",
-        "Remove-Item \"$dir\\dl.exe\""
-    ],
+    "innosetup": true,
     "uninstaller": {
         "script": [
             "$text = @(",
             "    'If you encounter \"file in use\" error during uninstallation, try the following steps:'",
             "    '    1. Launch MacType Wizard (macwiz.exe) and select \"Manual\" mode.'",
             "    '    2. Reboot.'",
-            "    '    3. Run `scoop uninstall mactype-np`.",
+            "    '    3. Run `scoop uninstall mactype-np`.'",
             ")",
             "warn $($text -join \"`r`n\")"
         ]
@@ -49,6 +45,6 @@
         "regex": "download/([\\w.-]+)/(?<filename>MacTypeInstaller_[\\w._-]+\\.exe)"
     },
     "autoupdate": {
-        "url": "https://github.com/snowie2000/mactype/releases/download/$version/$matchFilename#/dl.exe"
+        "url": "https://github.com/snowie2000/mactype/releases/download/$version/$matchFilename"
     }
 }


### PR DESCRIPTION
Universal extractor 2 just runs innounp to extract the installer, since scoop installs and uses innounp from the main bucket anytime the user installs something with `"innosetup": true` I cut out the middle man. Works with no tweaks needed.