### PR TITLE
sql-server-management-studio-np: add checkver, shortcut

### DIFF
--- a/bucket/sql-server-management-studio-np.json
+++ b/bucket/sql-server-management-studio-np.json
@@ -26,5 +26,14 @@
             "if ($rc -notin $success) { abort \"Uninstall failed, see log for details:`n$log\" }"
         ]
     },
-    "bin": "Common7\\IDE\\Ssms.exe"
+    "bin": "Common7\\IDE\\Ssms.exe",
+    "shortcuts": [
+        [
+            "Common7\\IDE\\Ssms.exe",
+            "SQL Server Management Studio"
+        ]
+    ],
+    "checkver": {
+        "regex": "Build number: (?<version>[\\d.]+)"
+    }
 }


### PR DESCRIPTION
Make version-agnostic 'Microsoft SQL Server Management Studio' shortcut
available from Start Menu.

Add support for checkver by parsing build number from the home page with
regex. No support for autoupdate, the actual file download url is
obfuscated by a few redirects originating with this [source url]. We
should not use this as the download url, because the link is reused for
new releases and results in a hash match error if the manifest is not
updated.

[source url]: https://aka.ms/ssmsfullsetup