### PR TITLE
sql-server-management-studio-np: Fix download

### DIFF
--- a/bucket/sql-server-management-studio-np.json
+++ b/bucket/sql-server-management-studio-np.json
@@ -3,7 +3,7 @@
     "description": "Integrated environment for SQL Server infrastructure administration and T-SQL development.",
     "homepage": "https://docs.microsoft.com/en-us/sql/ssms/download-sql-server-management-studio-ssms",
     "license": "Freeware",
-    "url": "https://aka.ms/ssmsfullsetup",
+    "url": "https://aka.ms/ssmsfullsetup#/SSMS-Setup-ENU.exe",
     "hash": "b7206b5118f45fab45138837da7f89eecdc17f3856febad56c1ffafae6940b41",
     "installer": {
         "script": [


### PR DESCRIPTION
Append download url with `#/<InstallerName>` syntax as described in the [`url`](https://github.com/lukesampson/scoop/wiki/App-Manifests#optional-properties) section. Required to rename file to `SSMS-Setup-ENU.exe` on download, which is required by installer script.