### PR TITLE
barrier: setup barrier virtual kvm

### DIFF
--- a/bucket/barrier-np.json
+++ b/bucket/barrier-np.json
@@ -1,6 +1,6 @@
 {
     "version": "2.3.2",
-    "description": "Barrier is software that mimics the functionality of a KVM switch, which historically would allow you to use a single keyboard and mouse to control multiple computers by physically turning a dial on the box to switch the machine you're controlling at any given moment. Barrier does this in software, allowing you to tell it which machine to control by moving your mouse to the edge of the screen, or by using a keypress to switch focus to a different system.",
+    "description": "Mimics the functionality of a KVM switch, which allows a single keyboard and mouse to control multiple machines.",
     "homepage": "https://github.com/debauchee/barrier",
     "license": "GPL-2.0",
     "url": "https://github.com/debauchee/barrier/releases/download/v2.3.2/BarrierSetup-2.3.2.exe",
@@ -13,7 +13,7 @@
         ]
     },
     "uninstaller": {
-        "script": "& \"$Env:Programfiles\\Barrier\\unins000.exe\" /verysilent /nocancel /norestart"
+        "script": "& \"$env:ProgramFiles\\Barrier\\unins000.exe\" /verysilent /nocancel /norestart"
     },
     "checkver": "github",
     "autoupdate": {

--- a/bucket/barrier.json
+++ b/bucket/barrier.json
@@ -1,0 +1,22 @@
+{
+    "version": "2.3.2",
+    "description": "Barrier is software that mimics the functionality of a KVM switch, which historically would allow you to use a single keyboard and mouse to control multiple computers by physically turning a dial on the box to switch the machine you're controlling at any given moment. Barrier does this in software, allowing you to tell it which machine to control by moving your mouse to the edge of the screen, or by using a keypress to switch focus to a different system.",
+    "homepage": "https://github.com/debauchee/barrier",
+    "license": "GPL-2.0",
+    "url": "https://github.com/debauchee/barrier/releases/download/v2.3.2/BarrierSetup-2.3.2.exe",
+    "hash": "a6a195c55c199b35c737d7494327b37da94ded4eb2592871d4ad747aa8baa39a",
+    "installer": {
+        "args": [
+            "/verysilent",
+            "/nocancel",
+            "/norestart"
+        ]
+    },
+    "uninstaller": {
+        "script": "& \"$Env:Programfiles\\Barrier\\unins000.exe\" /verysilent /nocancel /norestart"
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/debauchee/barrier/releases/download/v$version/BarrierSetup-$version.exe"
+    }
+}


### PR DESCRIPTION
Barrier is a fork of Synergy that focuses on stability and being simple
and free.

This installer is not completely hands-off. It requires permission
elevation because it needs to take control of your mouse (client) or add
a virtual monitor (server). The Barrier installer also asks to install
Bonjour (for discovery). It installs into Program Files. Seems like
nonportable is the right bucket.

This json is based on:
https://gist.github.com/pluser/239add9975080a01e2bb93b28e174acb

I changed the description and formatting.