### PR TITLE
Notepads-np - Global install for all users

### DIFF
--- a/bucket/notepads-np.json
+++ b/bucket/notepads-np.json
@@ -37,7 +37,8 @@
             "    reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock\" /t REG_DWORD /f /v \"AllowDevelopmentWithoutDevLicense\" /d \"1\"",
             "}",
             "",
-            "Add-AppxPackage \"$dir\\$notepads.msixbundle\""
+            "Add-AppxProvisionedPackage -Online -PackagePath \"$dir\\$notepads.msixbundle\" -SkipLicense | Out-Null",
+            "Start-Sleep -Seconds 2"
         ]
     },
     "post_install": [
@@ -50,8 +51,6 @@
             "    error \"Administrator rights are required to uninstall $app.\"",
             "    exit 1",
             "}",
-            "",
-            "taskkill /im Notepads.exe /f | Out-Null",
             "",
             "$name = (Get-AppxPackage -Name *Notepads*).PackageFamilyName",
             "Copy-Item \"$env:LocalAppData\\Packages\\$name\\Settings\" -Destination \"$dir\" -Force -Recurse | Out-Null",


### PR DESCRIPTION
The app will now globally install for all users(uninstall was already global). Although a minimum 2 seconds waiting needs to be added to the script, otherwise post-install wont persist settings(it would still be installing in the background).
Taskill will throw an error if app is not opened, so I removed it. Its a given that you are supposed to close an app during update or uninstall(in this case it wont persist settings).