### PR TITLE
mactype-np: Add persist

### DIFF
--- a/bucket/mactype-np.json
+++ b/bucket/mactype-np.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/snowie2000/mactype/releases/download/2019.1-beta6/MacTypeInstaller_2019.1-beta6.exe",
     "hash": "d4d84bbb0d67480ac9c19d9f60874a496c84c54852e12f6b85e1c8ccb8c123ed",
     "innosetup": true,
+    "persist": ["ini", "MacType.ini"],
     "uninstaller": {
         "script": [
             "$text = @(",

--- a/bucket/mactype-np.json
+++ b/bucket/mactype-np.json
@@ -15,7 +15,6 @@
     "url": "https://github.com/snowie2000/mactype/releases/download/2019.1-beta6/MacTypeInstaller_2019.1-beta6.exe",
     "hash": "d4d84bbb0d67480ac9c19d9f60874a496c84c54852e12f6b85e1c8ccb8c123ed",
     "innosetup": true,
-    "persist": ["ini", "MacType.ini"],
     "uninstaller": {
         "script": [
             "$text = @(",
@@ -40,6 +39,10 @@
             "MacWiz.exe",
             "MacType Wizard"
         ]
+    ],
+    "persist": [
+        "ini",
+        "MacType.ini"
     ],
     "checkver": {
         "url": "https://github.com/snowie2000/mactype/releases",


### PR DESCRIPTION
It may not make sense to persist some `nonportable` app's file, but MacType is portable to some extent, so here it is. Feel free to close this if you find it inappropriate.