### PR TITLE
flash-drive-tester-np: Add version 1.14

### DIFF
--- a/bucket/flash-drive-tester-np.json
+++ b/bucket/flash-drive-tester-np.json
@@ -1,0 +1,27 @@
+{
+    "version": "1.14",
+    "description": "Testing any removable media including SD, CF, USB flash drives.",
+    "homepage": "https://www.vconsole.com/download",
+    "license": "Freeware",
+    "url": "https://www.vconsole.com/ckfinder/userfiles/images/files/Flash_Drive_Tester_v114.exe#/dl.7z",
+    "hash": "52296cf464bd1d9e96e12529a57e73593d370e07c7bdbd951e68a0bd37de622e",
+    "installer": {
+        "script": [
+            "Rename-Item \"$dir\\Flash Drive Tester.msi\" 'setup.msi'",
+            "Remove-Item \"$dir\\setup.exe\"",
+            "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi\", '/qn', '/norestart', \"TARGETDIR=$dir\", \"INSTALLDIR=$dir\") -RunAs | Out-Null",
+            "Remove-Item \"$([Environment]::GetFolderPath('Desktop'))\\Flash Drive Tester*.lnk\"",
+            "Remove-Item -Recurse \"$([Environment]::GetFolderPath('startmenu'))\\Programs\\Virtual Console\""
+        ]
+    },
+    "uninstaller": {
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/x', \"$dir\\setup.msi\", '/qn', '/norestart') -RunAs | Out-Null"
+    },
+    "bin": "FlashTester.exe",
+    "shortcuts": [
+        [
+            "FlashTester.exe",
+            "Flash Drive Tester"
+        ]
+    ]
+}

--- a/bucket/flash-drive-tester-np.json
+++ b/bucket/flash-drive-tester-np.json
@@ -1,6 +1,6 @@
 {
     "version": "1.14",
-    "description": "Testing any removable media including SD, CF, USB flash drives.",
+    "description": "Tool for testing removable media for bad or unstable sectors.",
     "homepage": "https://www.vconsole.com/download",
     "license": "Freeware",
     "url": "https://www.vconsole.com/ckfinder/userfiles/images/files/Flash_Drive_Tester_v114.exe#/dl.7z",


### PR DESCRIPTION
**Flash Drive Tester** ([homepage](https://www.vconsole.com/download)) allows testing of any removable media including SD, CF, USB flash drives for bad or unstable sectors. Especially useful for testing for fake sizes often seen on low quality USB flash drives.

Notes:
* This package is sent here (instead of the [extra bucket](https://github.com/lukesampson/scoop-extras/)) because the MSI installer cannot be properly extracted using *7-zip* or *lessmsi*.

* *checkver/autoupdate* is not needed because *Flash Drive Tester* has not been updated since 2009.