### PR TITLE
anki-np: Add version 2.1.26

### DIFF
--- a/bucket/anki-np.json
+++ b/bucket/anki-np.json
@@ -1,0 +1,54 @@
+{
+    "version": "2.1.26",
+    "description": "Powerful and intelligent flash cards",
+    "homepage": "https://apps.ankiweb.net",
+    "license": "AGPL-3.0-only",
+    "suggest": {
+        "vcredist": "extras/vcredist2008"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ankitects/anki/releases/download/2.1.26/anki-2.1.26-windows.exe#/installer.exe",
+            "hash": "5881a7424530ef75a2afdd9f579a87be288dd6d8248a9670a55b28e4f6eae8a8"
+        },
+        "32bit": {
+            "url": "https://github.com/ankitects/anki/releases/download/2.1.26/anki-2.1.26-windows-alternate.exe#/installer.exe",
+            "hash": "38dd163df25e5ee216f5c194e71de8f71413e55e060b82d3dd8741a5724aecf4"
+        }
+    },
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand \"$dir\\installer.exe\" -ArgumentList @('/S', \"/D=$dir\") -RunAs | Out-Null",
+            "Remove-Item \"$([Environment]::GetFolderPath('commonstartmenu'))\\Programs\\Anki.lnk\""
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Invoke-ExternalCommand \"$dir\\uninstall.exe\" -ArgumentList @('/S') -RunAs | Out-Null"
+        ]
+    },
+    "bin": "anki.exe",
+    "shortcuts": [
+        [
+            "anki.exe",
+            "Anki"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/ankitects/anki/releases",
+        "regex": "anki-([\\d.]+)-windows\\.exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ankitects/anki/releases/download/$version/anki-$version-windows.exe#/installer.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/ankitects/anki/releases/download/$version/anki-$version-windows-alternate.exe#/installer.exe"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/anki-$version-checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
This adds a non portable version as the version in [extras](https://github.com/lukesampson/scoop-extras/blob/master/bucket/anki.json) uses many tricks in order to use a persist folder, which makes it clunky to use (cmd shell at startup, which is incidentally less responsive).
The only issue with this NP version is that the uninstaller does not use the /S flag, which I let it anyway as it may change in the future. The installation is correctly silent however.