### PR TITLE
nvidia-display-driver: Fix install script

### DIFF
--- a/bucket/nvidia-display-driver-np.json
+++ b/bucket/nvidia-display-driver-np.json
@@ -18,10 +18,10 @@
     },
     "installer": {
         "script": [
-            "$service_disabled = (Get-WMIObject win32_service -Filter \"name='NVDisplay.ContainerLocalSystem'\" -ComputerName '.').StartMode -eq 'Disabled'",
+            "$service_disabled = (Get-CimInstance win32_service -Filter \"name='NVDisplay.ContainerLocalSystem'\").StartMode -eq 'Disabled'",
             "",
             "New-Item \"$dir\\extract\" -ItemType Directory | Out-Null",
-            "Move-Item \"$dir\\*\" -Destination \"$dir\\extract\"",
+            "Move-Item \"$dir\\*\" -Exclude \"extract\" -Destination \"$dir\\extract\"",
             "New-Item \"$dir\\setup\" -ItemType Directory | Out-Null",
             "# Move everything we want",
             "Move-Item \"$dir\\extract\\Display.Driver\" -Destination \"$dir\\setup\"",

--- a/bucket/nvidia-display-driver-with-3d-vision-np.json
+++ b/bucket/nvidia-display-driver-with-3d-vision-np.json
@@ -18,10 +18,10 @@
     },
     "installer": {
         "script": [
-            "$service_disabled = (Get-WMIObject win32_service -Filter \"name='NVDisplay.ContainerLocalSystem'\" -ComputerName '.').StartMode -eq 'Disabled'",
+            "$service_disabled = (Get-CimInstance win32_service -Filter \"name='NVDisplay.ContainerLocalSystem'\").StartMode -eq 'Disabled'",
             "",
             "New-Item \"$dir\\extract\" -ItemType Directory | Out-Null",
-            "Move-Item \"$dir\\*\" -Destination \"$dir\\extract\"",
+            "Move-Item \"$dir\\*\" -Exclude \"extract\" -Destination \"$dir\\extract\"",
             "New-Item \"$dir\\setup\" -ItemType Directory | Out-Null",
             "# Move everything we want",
             "Move-Item \"$dir\\extract\\Display.Driver\" -Destination \"$dir\\setup\"",


### PR DESCRIPTION
As explained in PR #164 , this fixes the install scripts for `nvidia-display-driver-np` and `nvidia-display-driver-with-3d-vision-np`.