### PR TITLE
nvidia-display-driver-dch: Fix autoupdate

### DIFF
--- a/bucket/nvidia-display-driver-dch-np.json
+++ b/bucket/nvidia-display-driver-dch-np.json
@@ -12,7 +12,7 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://us.download.nvidia.com/Windows/451.67/451.67-desktop-win10-64bit-international-whql.exe#/dl.7z",
+            "url": "https://us.download.nvidia.com/Windows/451.67/451.67-desktop-win10-64bit-international-dch-whql.exe#/dl.7z",
             "hash": "98389ba661f66f09a36662e932fd5a7ccb62918986c124b8dd780e62adb1f2af"
         }
     },
@@ -54,7 +54,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://us.download.nvidia.com/Windows/$version/$version-desktop-win10-64bit-international-whql.exe#/dl.7z"
+                "url": "https://us.download.nvidia.com/Windows/$version/$version-desktop-win10-64bit-international-dch-whql.exe#/dl.7z"
             }
         }
     }

--- a/bucket/nvidia-display-driver-dch-with-3d-vision-np.json
+++ b/bucket/nvidia-display-driver-dch-with-3d-vision-np.json
@@ -12,7 +12,7 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://us.download.nvidia.com/Windows/451.67/451.67-desktop-win10-64bit-international-whql.exe#/dl.7z",
+            "url": "https://us.download.nvidia.com/Windows/451.67/451.67-desktop-win10-64bit-international-dch-whql.exe#/dl.7z",
             "hash": "98389ba661f66f09a36662e932fd5a7ccb62918986c124b8dd780e62adb1f2af"
         }
     },
@@ -56,7 +56,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://us.download.nvidia.com/Windows/$version/$version-desktop-win10-64bit-international-whql.exe#/dl.7z"
+                "url": "https://us.download.nvidia.com/Windows/$version/$version-desktop-win10-64bit-international-dch-whql.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
It seems like I had forgotten to correct the links in the autoupdate parts of the DCH drivers. It is fixed here.