### PR TITLE
zadig-np: Add version 2.5

### DIFF
--- a/bucket/zadig-np.json
+++ b/bucket/zadig-np.json
@@ -1,0 +1,23 @@
+{
+    "version": "2.5",
+    "description": "Installs generic USB drivers, such as WinUSB, libusb-win32/libusb0.sys or libusbK.",
+    "homepage": "https://zadig.akeo.ie/",
+    "license": "GPL-3.0-or-later",
+    "url": "https://github.com/pbatard/libwdi/releases/download/b730/zadig-2.5.exe#/zadig.exe",
+    "hash": "78a1a26854fbc848284588a62c7fbec9c652f6a3218ba543783d369265df00d6",
+    "pre_install": [
+        "New-Item -Path 'HKCU:\\SOFTWARE\\Akeo Consulting\\Zadig' -Force | Out-Null",
+        "New-ItemProperty -Path 'HKCU:\\SOFTWARE\\Akeo Consulting\\Zadig' -Name 'UpdateCheckInterval' -Type DWord -Value 0xffffffff | Out-Null"
+    ],
+    "bin": "zadig.exe",
+    "shortcuts": [
+        [
+            "zadig.exe",
+            "Zadig"
+        ]
+    ],
+    "checkver": "releases/download/b(?<build>\\d+)/zadig-([\\d.]+)\\.exe",
+    "autoupdate": {
+        "url": "https://github.com/pbatard/libwdi/releases/download/b$matchBuild/zadig-2.5.exe#/zadig.exe"
+    }
+}


### PR DESCRIPTION
**Zadig** ([homepage](https://zadig.akeo.ie/)) is a Windows application that installs generic USB drivers, such as WinUSB, libusb-win32/libusb0.sys or libusbK, to help you access USB devices.

Notes:

* This package is sent here (instead of the [extras bucket](https://github.com/lukesampson/scoop-extras/)) because Zadig involves **driver installation** or **system tweaks**, which does not meet the criteria of the extras bucket.

* The **pre_install** script will set Zadig's built-in update as "disabled". (It is better to manage updates by Scoop)

* **persist** is not needed because Zadig stores its config data at `HKCU:\SOFTWARE\Akeo Consulting\Zadig`.


Please tell me if there is any problem. Thanks.