### PR TITLE
equalizer-apo-np: Add version 1.2.1

### DIFF
--- a/bucket/equalizer-apo-np.json
+++ b/bucket/equalizer-apo-np.json
@@ -1,0 +1,39 @@
+{
+    "version": "1.2.1",
+    "description": "A parametric/graphic equalizer",
+    "homepage": "https://sourceforge.net/projects/equalizerapo/",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.sourceforge.net/project/equalizerapo/1.2.1/EqualizerAPO64-1.2.1.exe#/setup.exe",
+            "hash": "sha1:e4c0c0cc5a489a04bd3ecd75d34c42166f8f9b00"
+        },
+        "32bit": {
+            "url": "https://downloads.sourceforge.net/project/equalizerapo/1.2.1/EqualizerAPO32-1.2.1.exe#/setup.exe",
+            "hash": "sha1:b03028116f14214a63ccd7574b09b32db4026b1a"
+        }
+    },
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList @('/S', \"/D=$dir\") -RunAs | Out-Null",
+            "Remove-Item \"$dir\\setup.exe\""
+        ]
+    },
+    "uninstaller": {
+        "script": "Invoke-ExternalCommand \"$([Environment]::GetFolderPath('programfiles'))\\EqualizerAPO\\Uninstall.exe\" -ArgumentList '/S' -RunAs | Out-Null"
+    },
+    "checkver": {
+        "url": "https://sourceforge.net/projects/equalizerapo/files/",
+        "regex": "equalizerapo/files/([\\d.]+)/"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/equalizerapo/$version/EqualizerAPO64-$version.exe#/setup.exe"
+            },
+            "32bit": {
+                "url": "https://downloads.sourceforge.net/project/equalizerapo/$version/EqualizerAPO32-$version.exe#/setup.exe"
+            }
+        }
+    }
+}

--- a/bucket/equalizer-apo-np.json
+++ b/bucket/equalizer-apo-np.json
@@ -1,6 +1,6 @@
 {
     "version": "1.2.1",
-    "description": "A parametric/graphic equalizer",
+    "description": "Parametric/graphic equalizer",
     "homepage": "https://sourceforge.net/projects/equalizerapo/",
     "license": "GPL-2.0-only",
     "architecture": {


### PR DESCRIPTION
Requested in lukesampson/scoop-extras#4018

**Equailzer APO** ([homepage](https://sourceforge.net/projects/equalizerapo/)) is a parametric/graphic equalizer.

Notes:

* **installation path**: The installer is created with NSIS. I tried putting `/D=$dir` in the arguments, but it seems not working.
Also, the benchmark program (`benchmark.exe`) only reads config from `C:\Program Files\EqualizerAPO\config\config.txt`. Modifying the path will cause error.

* **persist** is not needed because the installer/uninstaller of Equalizer APO will not delete the config files. (which are under the `config` folder of the installation path)

Please tell me if there is any problem. Thanks.