### PR TITLE
equalizer-apo-np: Clean installer.script

### DIFF
--- a/bucket/equalizer-apo-np.json
+++ b/bucket/equalizer-apo-np.json
@@ -29,7 +29,7 @@
             "    $configurator_process | ForEach-Object { Stop-Process -Id $_.Id }",
             "} | Out-Null",
             "",
-            "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList @('/S', \"/D=$dir\") | Out-Null",
+            "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList '/S' | Out-Null",
             "Remove-Item \"$dir\\setup.exe\""
         ]
     },


### PR DESCRIPTION
This will remove the unnecessary `/D=$dir` in *installer.script*. 

I didn't notice it when sending the PR. Sorry.
