### PR TITLE
xampp-np: Add version 7.4.8-0

### DIFF
--- a/bucket/xampp-np.json
+++ b/bucket/xampp-np.json
@@ -4,7 +4,6 @@
     "homepage": "https://www.apachefriends.org/index.html",
     "license": "GPL-2.0-only",
     "notes": "Run XAMPP Control Panel with admin rights to avoid access errors.",
-    "depends": "sudo",
     "suggest": {
         "Visual C++ 2019 Redistributable": "extras/vcredist2019"
     },
@@ -16,9 +15,14 @@
     },
     "installer": {
         "script": [
-            "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList @('--mode', 'unattended', '--launchapps', '0') -RunAs | Out-Null",
+            "if (!(is_admin)) {",
+            "    error \"Administrator rights are required to install $app.\"",
+            "    exit 1",
+            "}",
+            "",
+            "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList @('--mode', 'unattended', '--launchapps', '0') | Out-Null",
             "Remove-Item \"$dir\\setup.exe\"",
-            "if (Test-Path $persist_dir) { sudo Copy-Item -Path \"$persist_dir\\*\" -Destination \"C:\\xampp\" -Force -Recurse }"
+            "if (Test-Path $persist_dir) { Copy-Item -Path \"$persist_dir\\*\" -Destination \"$env:HOMEDRIVE\\xampp\" -Force -Recurse }"
         ]
     },
     "uninstaller": {
@@ -26,9 +30,9 @@
             "$persist_files = @('apache\\conf', 'apache\\logs', 'htdocs', 'mysql\\data', 'php\\php.ini', 'sendmail\\sendmail.ini', 'tomcat\\conf', 'tomcat\\logs', 'xampp-control.ini')",
             "$persist_files | ForEach-Object {",
             "    ensure \"$persist_dir\\$_\\..\" | Out-Null",
-            "    Copy-Item -Path \"C:\\xampp\\$_\" -Destination \"$persist_dir\\$_\" -Force -Recurse",
+            "    Copy-Item -Path \"$env:HOMEDRIVE\\xampp\\$_\" -Destination \"$persist_dir\\$_\" -Force -Recurse",
             "}",
-            "Invoke-ExternalCommand \"C:\\xampp\\uninstall.exe\" -ArgumentList @('--mode', 'unattended') -RunAs | Out-Null"
+            "Invoke-ExternalCommand \"$env:HOMEDRIVE\\xampp\\uninstall.exe\" -ArgumentList @('--mode', 'unattended') -RunAs | Out-Null"
         ]
     },
     "checkver": "xampp-windows-x64-([\\d.-]+)-VC(?<vc>\\d+)-installer\\.exe",

--- a/bucket/xampp-np.json
+++ b/bucket/xampp-np.json
@@ -1,0 +1,42 @@
+{
+    "version": "7.4.8-0",
+    "description": "Apache distribution containing MariaDB, PHP, and Perl",
+    "homepage": "https://www.apachefriends.org/index.html",
+    "license": "GPL-2.0-only",
+    "notes": "Run XAMPP Control Panel with admin rights to avoid access errors.",
+    "depends": "sudo",
+    "suggest": {
+        "Visual C++ 2019 Redistributable": "extras/vcredist2019"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.sourceforge.net/project/xampp/XAMPP%20Windows/7.4.8/xampp-windows-x64-7.4.8-0-VC15-installer.exe#/setup.exe",
+            "hash": "sha1:9c12a89fea0bd3b82f16b2db57f7e6de26dacf12"
+        }
+    },
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList @('--mode', 'unattended', '--launchapps', '0') -RunAs | Out-Null",
+            "Remove-Item \"$dir\\setup.exe\"",
+            "if (Test-Path $persist_dir) { sudo Copy-Item -Path \"$persist_dir\\*\" -Destination \"C:\\xampp\" -Force -Recurse }"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "$persist_files = @('apache\\conf', 'apache\\logs', 'htdocs', 'mysql\\data', 'php\\php.ini', 'sendmail\\sendmail.ini', 'tomcat\\conf', 'tomcat\\logs', 'xampp-control.ini')",
+            "$persist_files | ForEach-Object {",
+            "    ensure \"$persist_dir\\$_\\..\" | Out-Null",
+            "    Copy-Item -Path \"C:\\xampp\\$_\" -Destination \"$persist_dir\\$_\" -Force -Recurse",
+            "}",
+            "Invoke-ExternalCommand \"C:\\xampp\\uninstall.exe\" -ArgumentList @('--mode', 'unattended') -RunAs | Out-Null"
+        ]
+    },
+    "checkver": "xampp-windows-x64-([\\d.-]+)-VC(?<vc>\\d+)-installer\\.exe",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/xampp/XAMPP%20Windows/$matchHead/xampp-windows-x64-$version-VC$matchVc-installer.exe#/setup.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
requested in lukesampson/scoop-extras#3570

**XAMPP**([homepage](https://www.apachefriends.org/)) is an Apache distribution containing MariaDB, PHP, and Perl.

Notes:

* The Portable Version of XAMPP does not contain *FileZilla FTP* and *Mercury Mail Server*. (The service installations are also disabled). Non-portable version contains all the components.

* **XAMPP** installs at `C:\xampp` by default. Running the installer with `--help` will show available parameters. However `--prefix $dir` doesn't seem to work. The NSIS script (extracted from the installer) shows that install path is "hardcoded" as `C:\xampp`.

[xampp.nsi.txt](https://github.com/TheRandomLabs/scoop-nonportable/files/5136036/xampp.nsi.txt)

* I tried creating a **symbolic link** at `C:\xampp` that points to `(SCOOP_DIR)\apps\xampp-np\current` before installation, so that XAMPP will be installed at `(SCOOP_DIR)\apps\xampp-np\current`.
In this way, we can manage the bin/shortcuts by ourselves. However this causes the applications (e.g. apache, php, mariadb) **fail to start** because `C:\xampp\httpd.exe` and `(SCOOP_DIR)\apps\xampp-np\current\httpd.exe` are seen as different files. `(SCOOP_DIR)\apps\xampp-np\current\httpd.exe` will fail to start because **port 80** is already in use by `C:\xampp\httpd.exe`.

* **"persist"**: Usually we don't add persist for non-portable apps. However, in this case user will lost their config data after updating the `xampp-np` package through Scoop. I use the "copy-over" method to save the config files in `$persist_dir`.

* **suggest**: * `vcredist2017` is required according to the readme file.
> PHP in this package needs the Microsoft Visual C++ 2017 Redistributable package from
http://www.microsoft.com/en-us/download/. Please ensure that the VC++ 2017 runtime
libraries are installed on your system.
Since Visual C++ 2015, 2017 and 2019 all share the same redistributable files, I put **vcredist 2019** in `suggest`.
(https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)

Please tell me if there is any problem. Thanks.