### PR TITLE
winbtrfs-np: Handle non-zero success exit code

### DIFF
--- a/bucket/winbtrfs-np.json
+++ b/bucket/winbtrfs-np.json
@@ -7,10 +7,10 @@
     "url": "https://github.com/maharmstone/btrfs/releases/download/v1.7.5/btrfs-1.7.5.zip",
     "hash": "c2bea9e704eadd4cafe4140ba73367b5bff827299ef6375464c9d9e7ce7c20b7",
     "installer": {
-        "script": "Invoke-ExternalCommand PnPUtil -ArgumentList @('/add-driver', \"$dir\\btrfs.inf\", '/install') -RunAs | Out-Null"
+        "script": "Invoke-ExternalCommand PnPUtil -ArgumentList @('/add-driver', \"$dir\\btrfs.inf\", '/install') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the installation.' } | Out-Null"
     },
     "uninstaller": {
-        "script": "Invoke-ExternalCommand PnPUtil -ArgumentList @('/delete-driver', \"$dir\\btrfs.inf\", '/uninstall') -RunAs | Out-Null"
+        "script": "Invoke-ExternalCommand PnPUtil -ArgumentList @('/delete-driver', \"$dir\\btrfs.inf\", '/uninstall') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the uninstallation.' } | Out-Null"
     },
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
PnPUtil exits with code 3010 when the installation was successful but
needs a reboot to finalize [1].
This adds the appropriate -ContinueExitCodes option to the installer and
uninstaller scripts.

[1]: https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/pnputil-return-values