### PR TITLE
Update powertoys-np to 0.25.0

### DIFF
--- a/bucket/powertoys-np.json
+++ b/bucket/powertoys-np.json
@@ -6,7 +6,7 @@
     "depends": "dotnet-sdk",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.25.0/PowerToysSetup-0.25.0-x64.exe",
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.25.0/PowerToysSetup-0.25.0-x64.exe#/setup.exe_",
             "hash": "e857c78d68ff628e624d470871dea6197d9e58d74a183daf6418309812c3c91f"
         }
     },

--- a/bucket/powertoys-np.json
+++ b/bucket/powertoys-np.json
@@ -1,35 +1,28 @@
 {
-    "version": "0.21.1",
+    "version": "0.25.0",
     "description": "System utilities to maximize productivity.",
     "homepage": "https://github.com/microsoft/PowerToys",
     "license": "MIT",
     "depends": "dotnet-sdk",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.21.1/PowerToysSetup-0.21.1-x64.msi#/setup.msi_",
-            "hash": "ef63a70fc1c4b718410d3129d1691ab3814b4f7d1cea402e6507b0133ca2f09c"
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.25.0/PowerToysSetup-0.25.0-x64.exe",
+            "hash": "e857c78d68ff628e624d470871dea6197d9e58d74a183daf6418309812c3c91f"
         }
     },
     "installer": {
-        "script": [
-            "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi_\", '/qn', \"INSTALLFOLDER=`\"$dir`\"\") -RunAs | Out-Null",
-            "Remove-Item \"$([Environment]::GetFolderPath('commonstartmenu'))\\Programs\\PowerToys*.lnk\""
+        "args": [
+            "--silent"
         ]
     },
     "uninstaller": {
-        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/x', \"$dir\\setup.msi_\", '/qn') -RunAs | Out-Null"
+        "script": "( gwmi Win32_Product | ? Name -eq 'PowerToys (Preview)').uninstall()"
     },
-    "shortcuts": [
-        [
-            "PowerToys.exe",
-            "PowerToys"
-        ]
-    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysSetup-$version-x64.msi#/setup.msi_"
+                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysSetup-$version-x64.exe#/setup.exe_"
             }
         }
     }


### PR DESCRIPTION
Rewrite the config for the .exe installer. Without arguments, currently, I cannot change the original inst dir to the scoop dir. Test on Windows 10 Pro Ver.19042.
