### PR TITLE
dokany-np: Add version 1.4.0.1000

### DIFF
--- a/bucket/dokany-np.json
+++ b/bucket/dokany-np.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.4.0.1000",
+    "description": "User mode file system library for windows with FUSE Wrapper.",
+    "homepage": "https://dokan-dev.github.io/",
+    "license": "LGPL-3.0-or-later|MIT",
+    "url": "https://github.com/dokan-dev/dokany/releases/download/v1.4.0.1000/dokan.zip",
+    "hash": "6f7c2baf5838210dab1e21c3b2b945986e3cfa8ca2ebabb6dc2455b9830a6628",
+    "architecture": {
+        "64bit": {
+            "extract_dir": "x64/Release"
+        },
+        "32bit": {
+            "extract_dir": "Win32/Release"
+        }
+    },
+    "bin": "dokanctl.exe",
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand PnPUtil -ArgumentList @('/add-driver', \"$dir\\Driver\\dokan.inf\", '/install') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the installation.'; 259 = 'Installation status pending which probably means success (exit code 259).' } | Out-Null"
+        ]
+    },
+    "uninstaller": {
+        "script": "Invoke-ExternalCommand PnPUtil -ArgumentList @('/delete-driver', \"$dir\\Driver\\dokan.inf\", '/uninstall') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the uninstallation.' } | Out-Null"
+    },
+    "checkver": {
+        "github": "https://github.com/dokan-dev/dokany"
+    },
+    "autoupdate": {
+        "url": "https://github.com/dokan-dev/dokany/releases/download/v$version/dokan.zip"
+    }
+}


### PR DESCRIPTION
Thought this might be useful (I need it for https://github.com/bailey27/cppcryptfs).

Do you know if I can open a PR to include a manifest for cppcryptfs into the scoop-extras bucket and make it depend on dokany-np? 