### PR TITLE
anki-np: remove 32 bit and update to 2.1.37

### DIFF
--- a/bucket/anki-np.json
+++ b/bucket/anki-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.1.35",
+    "version": "2.1.37",
     "description": "Powerful and intelligent flash cards",
     "homepage": "https://apps.ankiweb.net",
     "license": "AGPL-3.0-only",
@@ -8,12 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ankitects/anki/releases/download/2.1.35/anki-2.1.35-windows.exe#/installer.exe",
-            "hash": "8ce954c481577c708e1ed1d526a1c010822adc6cdf06d33ffd8df439d8007241"
-        },
-        "32bit": {
-            "url": "https://github.com/ankitects/anki/releases/download/2.1.35/anki-2.1.35-windows-alternate.exe#/installer.exe",
-            "hash": "56cc7d7e757589962ba3a5a98b0c619961933deb81c7c0bf009e44e2480196b4"
+            "url": "https://github.com/ankitects/anki/releases/download/2.1.37/anki-2.1.37-windows.exe#/installer.exe",
+            "hash": "48e60500c0366f0fad691350c02f4cc0cfd9165f04576c37b6385f244c91a0f3"
         }
     },
     "installer": {
@@ -40,9 +36,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/ankitects/anki/releases/download/$version/anki-$version-windows.exe#/installer.exe"
-            },
-            "32bit": {
-                "url": "https://github.com/ankitects/anki/releases/download/$version/anki-$version-windows-alternate.exe#/installer.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
Since Anki 2.1.36, 32 bits builds are not supported (see [here](https://changes.ankiweb.net/#/?id=changes-in-2136)). This PR removes the 32 bits architecture from the manifest so that it can continue to get updated.
