### PR TITLE
dokany-np: Fix installer by using the msi packages

### DIFF
--- a/bucket/dokany-np.json
+++ b/bucket/dokany-np.json
@@ -3,29 +3,33 @@
     "description": "User mode file system library for windows with FUSE Wrapper.",
     "homepage": "https://dokan-dev.github.io/",
     "license": "LGPL-3.0-or-later|MIT",
-    "url": "https://github.com/dokan-dev/dokany/releases/download/v1.4.0.1000/dokan.zip",
-    "hash": "6f7c2baf5838210dab1e21c3b2b945986e3cfa8ca2ebabb6dc2455b9830a6628",
     "architecture": {
         "64bit": {
-            "extract_dir": "x64/Release"
+            "url": "https://github.com/dokan-dev/dokany/releases/download/v1.4.0.1000/Dokan_x64.msi#/setup.msi_",
+            "hash": "d5eb126cfe2582edd79923aec53e879b78c1f2696d144fc3680ccc858cc05c97"
         },
         "32bit": {
-            "extract_dir": "Win32/Release"
+            "url": "https://github.com/dokan-dev/dokany/releases/download/v1.4.0.1000/Dokan_x86.msi#/setup.msi_",
+            "hash": "6a7663e2d8c07e178a0ca552ef16c41a031800971fcfc7961f5657cbb8d27195"
         }
     },
-    "bin": "dokanctl.exe",
     "installer": {
-        "script": [
-            "Invoke-ExternalCommand PnPUtil -ArgumentList @('/add-driver', \"$dir\\Driver\\dokan.inf\", '/install') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the installation.'; 259 = 'Installation status pending which probably means success (exit code 259).' } | Out-Null"
-        ]
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi_\", '/qn', '/norestart') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the installation.' } | Out-Null"
     },
     "uninstaller": {
-        "script": "Invoke-ExternalCommand PnPUtil -ArgumentList @('/delete-driver', \"$dir\\Driver\\dokan.inf\", '/uninstall') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the uninstallation.' } | Out-Null"
+        "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/x', \"$dir\\setup.msi_\", '/qn', '/norestart') -RunAs -ContinueExitCodes @{ 3010 = 'A system reboot is required to finalize the uninstallation.' } | Out-Null"
     },
     "checkver": {
         "github": "https://github.com/dokan-dev/dokany"
     },
     "autoupdate": {
-        "url": "https://github.com/dokan-dev/dokany/releases/download/v$version/dokan.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/dokan-dev/dokany/releases/download/v$version/Dokan_x64.msi#/setup.msi_"
+            },
+            "32bit": {
+                "url": "https://github.com/dokan-dev/dokany/releases/download/v$version/Dokan_x86.msi#/setup.msi_"
+            }
+        }
     }
 }


### PR DESCRIPTION
The dokany.inf file does not correctly install the dokan1.sys and dokan1.dll files to %WINDIR%/system32.

It erroneously worked for me because I had installed dokany manually some time before installing via scoop.