### PR TITLE
cppcryptfs-np: Add version 1.4.3.5

### DIFF
--- a/bucket/cppcryptfs-np.json
+++ b/bucket/cppcryptfs-np.json
@@ -1,0 +1,37 @@
+{
+    "version": "1.4.3.5",
+    "description": "Implementation of the gocryptfs encrypted overlay filesystem in C++ for Windows.",
+    "homepage": "https://github.com/bailey27/cppcryptfs",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://github.com/bailey27/cppcryptfs/releases/download/1.4.3.5/cppcryptfs.exe",
+                "https://github.com/bailey27/cppcryptfs/releases/download/1.4.3.5/cppcryptfsctl.exe"
+            ],
+            "hash": [
+                "4cc34b35c810f428e94520a0df1bc662a6d3a609195db71f8ee04698f1922779",
+                "fd71c402a2fb517e71b3ee180afb308391bef9502e7af96b6d0d813764a3e327"
+            ]
+        },
+        "32bit": {
+            "url": [
+                "https://github.com/bailey27/cppcryptfs/releases/download/1.4.3.5/cppcryptfs32.exe#/cppcryptfs.exe",
+                "https://github.com/bailey27/cppcryptfs/releases/download/1.4.3.5/cppcryptfsctl32.exe#/cppcryptfsctl.exe"
+            ],
+            "hash": [
+                "09730edf0da51e84119e0e9b74cbb86f4c1888dad399f471f4ba160934e67711",
+                "c94ae2fb775260c8ee649bbc660ad8514fd936d48aeaf3b8cf0188492bd7e521"
+            ]
+        }
+    },
+    "bin": [
+        "cppcryptfsctl.exe",
+        "cppcryptfs.exe"
+    ],
+    "shortcuts": [
+        ["cppcryptfs.exe", "cppcryptfs"]
+    ],
+    "checkver": "github",
+    "depends": "dokany-np"
+}

--- a/bucket/cppcryptfs-np.json
+++ b/bucket/cppcryptfs-np.json
@@ -3,6 +3,7 @@
     "description": "Implementation of the gocryptfs encrypted overlay filesystem in C++ for Windows.",
     "homepage": "https://github.com/bailey27/cppcryptfs",
     "license": "MIT",
+    "depends": "dokany-np",
     "architecture": {
         "64bit": {
             "url": [
@@ -30,8 +31,10 @@
         "cppcryptfs.exe"
     ],
     "shortcuts": [
-        ["cppcryptfs.exe", "cppcryptfs"]
+        [
+            "cppcryptfs.exe",
+            "cppcryptfs"
+        ]
     ],
-    "checkver": "github",
-    "depends": "dokany-np"
+    "checkver": "github"
 }


### PR DESCRIPTION
This package was not accepted in the scoop-extras bucket because of the dependency on dokany-np (https://github.com/lukesampson/scoop-extras/pull/5305).

This is actually a portable app but I still added the `-np` suffix because all other apps in the bucket have it.