### PR TITLE
Fix teamviewer-np.json autoupdate

### DIFF
--- a/bucket/teamviewer-np.json
+++ b/bucket/teamviewer-np.json
@@ -1,17 +1,16 @@
 {
-    "version": "15.11.6",
+    "version": "15.13.6",
     "description": "Software for remote control, desktop sharing, online meetings, web conferencing and file transfer between computers.",
     "homepage": "https://www.teamviewer.com/",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.teamviewer.com/en/eula/"
     },
-    "url": "https://download.teamviewer.com/download/version_15x/TeamViewer_Setup.exe",
+    "url": "https://download.teamviewer.com/download/version_15x/TeamViewer_Setup.exe#/setup.exe",
     "hash": "f382d37be065629428b647e6f19ff9c02ee449fbf1e38b5ea768249368864553",
     "installer": {
         "script": [
             "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList @('/S', '/norestart') -RunAs | Out-Null",
-            "Remove-Item \"$([Environment]::GetFolderPath('commonstartmenu'))\\Programs\\TeamViewer.lnk\"",
             "Remove-Item \"$dir\\setup.exe\""
         ]
     },
@@ -28,6 +27,6 @@
         "regex": ">\\s*([\\d.]+)\\s*<"
     },
     "autoupdate": {
-        "url": "https://download.teamviewer.com/download/version_$majorVersionx/TeamViewer_Setup.exe"
+        "url": "https://download.teamviewer.com/download/version_$majorVersionx/TeamViewer_Setup.exe#/setup.exe"
     }
 }


### PR DESCRIPTION
The `autoupdate`'s url renaming is not consist with original installer script.
Plus, I deleted the code of removing teamviewer start menu shortcut. I prefer a start menu shortcut than a desktop shortcut. But that part may be approved in some other ways, too.