### PR TITLE
powertoys-np: Fix uninstall script

### DIFF
--- a/bucket/powertoys-np.json
+++ b/bucket/powertoys-np.json
@@ -14,7 +14,7 @@
         "args": "--silent"
     },
     "uninstaller": {
-        "script": "(Get-WmiObject Win32_Product | Where-Object Name -EQ 'PowerToys (Preview)').uninstall()"
+        "script": "cmd /c ((Get-ItemProperty -Path HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\* | Where-Object {$_.DisplayName -eq \"PowerToys (Preview)\"} | Select-Object -Expand UninstallString) -replace '/I','/x')"
     },
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
* closes #227 

`Get-WmiObject` is now deprecated and powertoys doesn't come with an uninstaller executable nor does it have a `.uninstall()` method.
Also, my first try was using `Get-CimInstance` but I thought "Hey that's super slow", so I'm proposing this script:

- Get the uninstallable softwares through the registry
- Filter out the PowerToys entry
- Isolate the UninstallString and replace `/I` by `/x`
- Execute the resulting command

Unfortunately, I've been struggling to make the uninstall quiet,
I tried `/qn`, `/passive` and `/quiet` but it just gives me an error,
so if someone more knowledgable has any suggestion, please let me know.