### PR TITLE
unity-hub-np: Add version 2.4.4

### DIFF
--- a/bucket/unity-hub-np.json
+++ b/bucket/unity-hub-np.json
@@ -1,0 +1,40 @@
+{
+    "version": "2.4.3",
+    "description": "Management tool for Unity installations and projects",
+    "homepage": "https://docs.unity3d.com/Manual/GettingStartedInstallingHub.html",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://unity3d.com/legal/terms-of-service"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.exe#/setup.exe",
+            "hash": "3cb22764ae2c467486448088d3c045e7d5d209b4adfeccc3e7de84beadb2ef36"
+        }
+    },
+    "installer": {
+        "script": [
+            "Invoke-ExternalCommand \"$dir\\setup.exe\" -ArgumentList @('/S', \"/D=$dir\") -RunAs | Out-Null",
+            "Remove-Item \"$dir\\setup.exe\""
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Invoke-ExternalCommand \"$dir\\Uninstall Unity Hub.exe\" -ArgumentList @('/S') -RunAs | Out-Null",
+            "while (Get-Process 'Un_A' -ErrorAction SilentlyContinue) {",
+            "    Start-Sleep -Seconds 1",
+            "}"
+        ]
+    },
+    "checkver": {
+        "url": "https://unity3d.com/hub/whats-new",
+        "regex": "content=\"##([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.exe#/setup.exe"
+            }
+        }
+    }
+}

--- a/bucket/unity-hub-np.json
+++ b/bucket/unity-hub-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.4.3",
+    "version": "2.4.4",
     "description": "Management tool for Unity installations and projects",
     "homepage": "https://docs.unity3d.com/Manual/GettingStartedInstallingHub.html",
     "license": {
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.exe#/setup.exe",
-            "hash": "3cb22764ae2c467486448088d3c045e7d5d209b4adfeccc3e7de84beadb2ef36"
+            "hash": "62c7acbfd59549d683bbe3c9370aa218550253edfc0f5674eb0611c7b7cdd562"
         }
     },
     "installer": {
@@ -28,7 +28,7 @@
     },
     "checkver": {
         "url": "https://unity3d.com/hub/whats-new",
-        "regex": "content=\"##([\\d.]+)"
+        "regex": "<h2>([\\d.]+)</h2>"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
* [**Unity Hub**](https://docs.unity3d.com/Manual/GettingStartedInstallingHub.html) is the official management tool for Unity installations and projects.

* **uninstaller script**: `while (Get-Process ...)` will let the uninstaller to finish before Scoop deletes all the files in `$dir`.

Please tell me if there is any problem. Thanks.