### PR TITLE
Create streamlink-np.json

### DIFF
--- a/bucket/streamlink-np.json
+++ b/bucket/streamlink-np.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.0.3",
+    "version": "3.1.1",
     "description": "A command-line utility that pipes video streams from various services into a video player.",
     "homepage": "https://streamlink.github.io/",
     "license": "BSD-2-Clause",
@@ -13,8 +13,8 @@
         "MPV Player": [ "extras/mpv", "extras/mpv-git" ]
         "Streamlink Twitch GUI": "extras/streamlink-twitch-gui"
     },
-    "url": "https://github.com/streamlink/streamlink/releases/download/3.0.3/streamlink-3.0.3.exe#/dl.7z",
-    "hash": "f6de6fcf2aa2bf532d18782ec1e9421b173bd627fc0e6faf8427807289483d37",
+    "url": "https://github.com/streamlink/streamlink/releases/download/3.1.1/streamlink-3.1.1.exe#/dl.7z",
+    "hash": "178c3edf3d49f4e76b67e1ee9b9984eef21a079cbf1a732b99c7bc42a7eec762",
     "pre_install": [
         "if (!(Test-Path \"$env:APPDATA\\streamlink\\config\")) {",
         "    info 'Copying default ''config'' to ''%APPDATA%\\streamlink\\config'''",

--- a/bucket/streamlink-np.json
+++ b/bucket/streamlink-np.json
@@ -1,0 +1,39 @@
+{
+    "version": "3.0.3",
+    "description": "A command-line utility that pipes video streams from various services into a video player.",
+    "homepage": "https://streamlink.github.io/",
+    "license": "BSD-2-Clause",
+    "notes": "Streamlink settings can be changed in '%APPDATA%\\streamlink\\config'",
+    "suggest": {
+        "FFmpeg": [
+            "ffmpeg",
+            "ffmpeg-nightly"
+        ],
+        "VLC Player": "extras/vlc"
+        "MPV Player": [ "extras/mpv", "extras/mpv-git" ]
+        "Streamlink Twitch GUI": "extras/streamlink-twitch-gui"
+    },
+    "url": "https://github.com/streamlink/streamlink/releases/download/3.0.3/streamlink-3.0.3.exe#/dl.7z",
+    "hash": "f6de6fcf2aa2bf532d18782ec1e9421b173bd627fc0e6faf8427807289483d37",
+    "pre_install": [
+        "if (!(Test-Path \"$env:APPDATA\\streamlink\\config\")) {",
+        "    info 'Copying default ''config'' to ''%APPDATA%\\streamlink\\config'''",
+        "    ensure \"$env:APPDATA\\streamlink\" | Out-Null",
+        "    Copy-Item \"$dir\\`$APPDATA\\streamlink\\config\" \"$env:APPDATA\\streamlink\\config\"",
+        "}",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\ffmpeg\", \"$dir\\uninstall.exe\" -Recurse"
+    ],
+    "uninstaller": {
+        "script": "if ($purge) { Remove-Item \"$env:APPDATA\\streamlink\" -Recurse}"
+    },
+    "bin": [
+        "bin\\streamlink.exe",
+        "bin\\streamlinkw.exe"
+    ],
+    "checkver": {
+        "github": "https://github.com/streamlink/streamlink"
+    },
+    "autoupdate": {
+        "url": "https://github.com/streamlink/streamlink/releases/download/$version/streamlink-$version.exe#/dl.7z"
+    }
+}


### PR DESCRIPTION
The extra bucket of scoop now offers a portable version of streamlink which provides a .bat executable of streamlink and not an executable .exe version like the installer one.
The .exe bin is necessary for programs like [Chatterino2](https://github.com/chatterino/chatterino2)

From: https://github.com/ScoopInstaller/Extras/blob/d87473dd2f173360f2b8b0b77dce728e7bbb7793/bucket/streamlink.json