### PR TITLE
sshfs-np: fix manifest

### DIFF
--- a/bucket/sshfs-np.json
+++ b/bucket/sshfs-np.json
@@ -13,9 +13,7 @@
             "hash": "9643daf27eb7e384dadc9e64a4299c8d92e6c91e07913e9425f5b19aad3b2ded"
         }
     },
-    "depends": {
-        "winfsp-np": "winfsp-np"
-    },
+    "depends": "winfsp-np",
     "installer": {
         "script": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi_\", '/qn') -RunAs | Out-Null"
     },


### PR DESCRIPTION
```
> scoop install sshfs-np
方法调用失败，因为 [Selected.System.Management.Automation.PSCustomObject] 不包含名为“TrimStart”的方法。
所在位置 C:\Users\MoeShin\scoop\apps\scoop\current\lib\manifest.ps1:28 字符: 5
+     $app = $app.TrimStart('/')
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (TrimStart:String) []，RuntimeException
    + FullyQualifiedErrorId : MethodNotFound

Couldn't find manifest for '@{winfsp-np=winfsp-np}'.
```
