### PR TITLE
Update calibre-np.json

### DIFF
--- a/bucket/calibre-np.json
+++ b/bucket/calibre-np.json
@@ -1,18 +1,13 @@
 {
-    "version": "5.44.0",
+    "version": "6.2.1",
     "description": "E-book manager.",
     "homepage": "https://calibre-ebook.com/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kovidgoyal/calibre/releases/download/v5.44.0/calibre-64bit-5.44.0.msi",
-            "hash": "708ba7db84ae9db684b643f81a4fb6b1c65f5e6dac0adc4721e6ed7d20677798",
+            "url": "https://github.com/kovidgoyal/calibre/releases/download/v6.2.1/calibre-64bit-6.2.1.msi",
+            "hash": "c95ab094cdf954c7d54c887434b5d77df121ed2a09bf1840712e7a1b23eb308a",
             "extract_dir": "PFiles\\Calibre2"
-        },
-        "32bit": {
-            "url": "https://github.com/kovidgoyal/calibre/releases/download/v5.44.0/calibre-5.44.0.msi",
-            "hash": "21903563b5bb5817ee33f3a3ea6b0f3b71c3eac1793069f89674d70a99f0f080",
-            "extract_dir": "PFiles\\Calibre"
         }
     },
     "bin": [
@@ -60,10 +55,8 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-64bit-$version.msi"
-            },
-            "32bit": {
-                "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-$version.msi"
             }
         }
     }
 }
+


### PR DESCRIPTION
Update the calibre manifest for current version. 32 bit version no longer available on release tab. Unless the portable version is 32 bit in which case I will update the manifest to use the portable.