### PR TITLE
virtualbox-np: remove VBoxSDL shim

### DIFF
--- a/bucket/virtualbox-np.json
+++ b/bucket/virtualbox-np.json
@@ -33,7 +33,6 @@
         "VBoxManage.exe",
         "VBoxNetDHCP.exe",
         "VBoxNetNAT.exe",
-        "VBoxSDL.exe",
         "VBoxSDS.exe",
         "VBoxSVC.exe",
         "VBoxTestOGL.exe",


### PR DESCRIPTION
VirtualBox 7.0.0 install fails due to being unable to shim `VBoxSDL.exe`, which is not present in https://download.virtualbox.org/virtualbox/7.0.0/VirtualBox-7.0.0-153978-Win.exe#/VBoxSetup.exe.