### PR TITLE
Update powertoys-np.json

### DIFF
--- a/bucket/powertoys-np.json
+++ b/bucket/powertoys-np.json
@@ -3,7 +3,6 @@
     "description": "System utilities to maximize productivity.",
     "homepage": "https://github.com/microsoft/PowerToys",
     "license": "MIT",
-    "depends": "dotnet-sdk",
     "architecture": {
         "64bit": {
             "url": "https://github.com/microsoft/PowerToys/releases/download/v0.66.0/PowerToysSetup-0.66.0-x64.exe#/setup.exe",


### PR DESCRIPTION
Dependency is not needed anymore.

"The .NET 7 dependency is now shipped self-contained within the utilities" Source: https://github.com/microsoft/PowerToys/releases/tag/v0.66.0

https://visualstudiomagazine.com/articles/2023/01/06/powertoys-net7.aspx